### PR TITLE
Remove canvas fill for `ImageBox::OnPaint()`

### DIFF
--- a/src/widgets/imagebox/imagebox.cpp
+++ b/src/widgets/imagebox/imagebox.cpp
@@ -24,7 +24,6 @@ void ImageBox::SetImage(std::shared_ptr<Image> newImage)
 
 void ImageBox::OnPaint(Canvas* canvas)
 {
-	canvas->fillRect(Rect::xywh(0.0, 0.0, GetWidth(), GetHeight()), Colorf::fromRgba8(0, 0, 0));
 	if (image)
 	{
 		canvas->drawImage(image, Point((GetWidth() - (double)image->GetWidth()) * 0.5, (GetHeight() - (double)image->GetHeight()) * 0.5));


### PR DESCRIPTION
Don't fill the rect when painting an ImageBox so PNGs with an alpha channel show against the dialog's colour.