### PR TITLE
Repair setup in `LineEdit::SetAlignment()` where comparison was against itself.

### DIFF
--- a/src/widgets/lineedit/lineedit.cpp
+++ b/src/widgets/lineedit/lineedit.cpp
@@ -123,11 +123,11 @@ void LineEdit::SetReadOnly(bool enable)
 	}
 }
 
-void LineEdit::SetAlignment(Alignment alignment)
+void LineEdit::SetAlignment(Alignment newalignment)
 {
-	if (alignment != alignment)
+	if (alignment != newalignment)
 	{
-		alignment = alignment;
+		alignment = newalignment;
 		Update();
 	}
 }


### PR DESCRIPTION
Warning received under a Clang compile.