### PR TITLE
reduce risk of stack overflows in libschrift

### DIFF
--- a/src/core/schrift/schrift.cpp
+++ b/src/core/schrift/schrift.cpp
@@ -1548,7 +1548,7 @@ render_outline(Outline *outl, double transform[6], SFT_Image image)
 	
 	numPixels = (unsigned int) image.width * (unsigned int) image.height;
 
-	STACK_ALLOC(cells, Cell, 128 * 128, numPixels);
+	STACK_ALLOC(cells, Cell, 32 * 32, numPixels);
 	if (!cells) {
 		return -1;
 	}


### PR DESCRIPTION
This was allocating a 256kb buffer on the stack, which is now reduced to 16 kb.
On Windows with a stack size of 1MB this is way too risky.
