### PR TITLE
include SDL2 directory to fix mac compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ target_link_options(zwidget PRIVATE ${ZWIDGET_LINK_OPTIONS})
 target_link_libraries(zwidget ${ZWIDGET_LIBS})
 set_target_properties(zwidget PROPERTIES CXX_STANDARD 20)
 target_compile_options(zwidget PRIVATE ${CXX_WARNING_FLAGS})
+target_include_directories(zwidget PRIVATE ${SDL2_INCLUDE_DIRS})
 
 if(MSVC)
 	set_property(TARGET zwidget PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
Fix: Missing SDL2 Include Directory in CMake-generated Makefile

This Pull Request fixes an issue in the `CMakeLists.txt` where the SDL2 include directory is not properly set. This causes the following compilation error:

```
In file included from /tmp/ZWidget/src/window/sdl2/sdl2_display_window.cpp:2:
/tmp/ZWidget/src/window/sdl2/sdl2_display_window.h:7:10: fatal error: 'SDL2/SDL.h' file not found
    7 | #include <SDL2/SDL.h>
```

The issue was encountered on **macOS 15.5** with **SDL2 installed via Homebrew**.

In addition, I noticed that macOS build CI is currently disabled — this fix may help re-enable successful builds on macOS.

Thank you!

Best regards,  
**Rafa**