### PR TITLE
WaylandDisplayBackend: New protocols and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ set(ZWIDGET_WAYLAND_SOURCES
 	src/window/wayland/wayland_display_window.h
 	src/window/wayland/wl_fractional_scaling_protocol.cpp
 	src/window/wayland/wl_fractional_scaling_protocol.hpp
+	src/window/wayland/wl_cursor_shape.cpp
+	src/window/wayland/wl_cursor_shape.hpp
+	src/window/wayland/wl_xdg_toplevel_icon.cpp
+	src/window/wayland/wl_xdg_toplevel_icon.hpp
 )
 
 source_group("src" REGULAR_EXPRESSION "${CMAKE_CURRENT_SOURCE_DIR}/src/.+")

--- a/src/window/wayland/wayland_display_backend.h
+++ b/src/window/wayland/wayland_display_backend.h
@@ -9,10 +9,13 @@
 #include <wayland-client-protocol-unstable.hpp>
 #include <wayland-cursor.hpp>
 #include "wl_fractional_scaling_protocol.hpp"
+#include "wl_xdg_toplevel_icon.hpp"
 #include <linux/input.h>
 #include <poll.h>
 #include <map>
 #include <xkbcommon/xkbcommon.h>
+
+#include "wl_cursor_shape.hpp"
 
 static short poll_single(int fd, short events, int timeout)
 {
@@ -118,6 +121,11 @@ public:
 	wayland::zwp_relative_pointer_manager_v1_t m_RelativePointerManager;
 	wayland::zwp_relative_pointer_v1_t m_RelativePointer;
 
+	wayland::xdg_toplevel_icon_manager_v1_t m_XDGToplevelIconManager;
+
+	wayland::cursor_shape_manager_v1_t m_CursorShapeManager;
+	wayland::cursor_shape_device_v1_t m_CursorShapeDevice;
+
 	wayland::cursor_image_t m_cursorImage;
 	wayland::surface_t m_cursorSurface;
 	wayland::buffer_t m_cursorBuffer;
@@ -146,6 +154,7 @@ private:
 	InputKey XKBKeySymToInputKey(xkb_keysym_t keySym);
 	InputKey LinuxInputEventCodeToInputKey(uint32_t inputCode);
 
+	wayland::cursor_shape_device_v1_shape GetWaylandCursorShape(StandardCursor cursor);
 	std::string GetWaylandCursorName(StandardCursor cursor);
 
 	bool hasKeyboard = false;
@@ -162,6 +171,7 @@ private:
 	std::string previousChars;
 
 	uint32_t m_KeyboardSerial = 0;
+	uint32_t m_MouseSerial = 0;
 
 	xkb_context* m_KeymapContext = nullptr;
 	xkb_keymap* m_Keymap = nullptr;

--- a/src/window/wayland/wayland_display_window.h
+++ b/src/window/wayland/wayland_display_window.h
@@ -182,6 +182,8 @@ private:
 	wayland::zwp_locked_pointer_v1_t m_LockedPointer;
 	wayland::zwp_confined_pointer_v1_t m_ConfinedPointer;
 
+	wayland::xdg_toplevel_icon_v1_t m_XDGToplevelIcon;
+
 	wayland::callback_t m_FrameCallback;
 
 	std::string m_windowID;
@@ -189,10 +191,15 @@ private:
 
 	std::shared_ptr<SharedMemHelper> shared_mem;
 
+	std::vector<std::shared_ptr<SharedMemHelper>> appIconSharedMems;
+	std::vector<wayland::buffer_t> appIconBuffers;
+
 	bool isFullscreen = false;
 
 	// Helper functions
 	void CreateBuffers(int32_t width, int32_t height);
+
+	void CreateAppIconBuffers(const std::vector<std::shared_ptr<Image>>& images);
 	std::string GetWaylandWindowID();
 
 	friend WaylandDisplayBackend;

--- a/src/window/wayland/wl_cursor_shape.cpp
+++ b/src/window/wayland/wl_cursor_shape.cpp
@@ -1,0 +1,218 @@
+#include "wl_cursor_shape.hpp"
+
+using namespace wayland;
+using namespace wayland::detail;
+
+const wl_interface* cursor_shape_manager_v1_interface_destroy_request[0] = {
+};
+
+const wl_interface* cursor_shape_manager_v1_interface_get_pointer_request[2] = {
+  &cursor_shape_device_v1_interface,
+  &pointer_interface,
+};
+
+const wl_interface* cursor_shape_manager_v1_interface_get_tablet_tool_v2_request[2] = {
+  &cursor_shape_device_v1_interface,
+  &zwp_tablet_tool_v2_interface,
+};
+
+const wl_message cursor_shape_manager_v1_interface_requests[3] = {
+  {
+    "destroy",
+    "",
+    cursor_shape_manager_v1_interface_destroy_request,
+  },
+  {
+    "get_pointer",
+    "no",
+    cursor_shape_manager_v1_interface_get_pointer_request,
+  },
+  {
+    "get_tablet_tool_v2",
+    "no",
+    cursor_shape_manager_v1_interface_get_tablet_tool_v2_request,
+  },
+};
+
+const wl_message cursor_shape_manager_v1_interface_events[0] = {
+};
+
+const wl_interface wayland::detail::cursor_shape_manager_v1_interface =
+  {
+    "wp_cursor_shape_manager_v1",
+    2,
+    3,
+    cursor_shape_manager_v1_interface_requests,
+    0,
+    cursor_shape_manager_v1_interface_events,
+  };
+
+const wl_interface* cursor_shape_device_v1_interface_destroy_request[0] = {
+};
+
+const wl_interface* cursor_shape_device_v1_interface_set_shape_request[2] = {
+  nullptr,
+  nullptr,
+};
+
+const wl_message cursor_shape_device_v1_interface_requests[2] = {
+  {
+    "destroy",
+    "",
+    cursor_shape_device_v1_interface_destroy_request,
+  },
+  {
+    "set_shape",
+    "uu",
+    cursor_shape_device_v1_interface_set_shape_request,
+  },
+};
+
+const wl_message cursor_shape_device_v1_interface_events[0] = {
+};
+
+const wl_interface wayland::detail::cursor_shape_device_v1_interface =
+  {
+    "wp_cursor_shape_device_v1",
+    2,
+    2,
+    cursor_shape_device_v1_interface_requests,
+    0,
+    cursor_shape_device_v1_interface_events,
+  };
+
+cursor_shape_manager_v1_t::cursor_shape_manager_v1_t(const proxy_t &p)
+  : proxy_t(p)
+{
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&cursor_shape_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_manager_v1_t(p); });
+}
+
+cursor_shape_manager_v1_t::cursor_shape_manager_v1_t()
+{
+  set_interface(&cursor_shape_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_manager_v1_t(p); });
+}
+
+cursor_shape_manager_v1_t::cursor_shape_manager_v1_t(wp_cursor_shape_manager_v1 *p, wrapper_type t)
+  : proxy_t(reinterpret_cast<wl_proxy*> (p), t){
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&cursor_shape_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_manager_v1_t(p); });
+}
+
+cursor_shape_manager_v1_t::cursor_shape_manager_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/)
+  : proxy_t(wrapped_proxy, construct_proxy_wrapper_tag()){
+  set_interface(&cursor_shape_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_manager_v1_t(p); });
+}
+
+cursor_shape_manager_v1_t cursor_shape_manager_v1_t::proxy_create_wrapper()
+{
+  return {*this, construct_proxy_wrapper_tag()};
+}
+
+const std::string cursor_shape_manager_v1_t::interface_name = "wp_cursor_shape_manager_v1";
+
+cursor_shape_manager_v1_t::operator wp_cursor_shape_manager_v1*() const
+{
+  return reinterpret_cast<wp_cursor_shape_manager_v1*> (c_ptr());
+}
+
+cursor_shape_device_v1_t cursor_shape_manager_v1_t::get_pointer(pointer_t const& pointer)
+{
+  proxy_t p = marshal_constructor(1U, &cursor_shape_device_v1_interface, nullptr, pointer.proxy_has_object() ? reinterpret_cast<wl_object*>(pointer.c_ptr()) : nullptr);
+  return cursor_shape_device_v1_t(p);
+}
+
+
+cursor_shape_device_v1_t cursor_shape_manager_v1_t::get_tablet_tool_v2(zwp_tablet_tool_v2_t const& tablet_tool)
+{
+  proxy_t p = marshal_constructor(2U, &cursor_shape_device_v1_interface, nullptr, tablet_tool.proxy_has_object() ? reinterpret_cast<wl_object*>(tablet_tool.c_ptr()) : nullptr);
+  return cursor_shape_device_v1_t(p);
+}
+
+
+int cursor_shape_manager_v1_t::dispatcher(uint32_t opcode, const std::vector<any>& args, const std::shared_ptr<detail::events_base_t>& e)
+{
+  return 0;
+}
+
+cursor_shape_device_v1_t::cursor_shape_device_v1_t(const proxy_t &p)
+  : proxy_t(p)
+{
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&cursor_shape_device_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_device_v1_t(p); });
+}
+
+cursor_shape_device_v1_t::cursor_shape_device_v1_t()
+{
+  set_interface(&cursor_shape_device_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_device_v1_t(p); });
+}
+
+cursor_shape_device_v1_t::cursor_shape_device_v1_t(wp_cursor_shape_device_v1 *p, wrapper_type t)
+  : proxy_t(reinterpret_cast<wl_proxy*> (p), t){
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&cursor_shape_device_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_device_v1_t(p); });
+}
+
+cursor_shape_device_v1_t::cursor_shape_device_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/)
+  : proxy_t(wrapped_proxy, construct_proxy_wrapper_tag()){
+  set_interface(&cursor_shape_device_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return cursor_shape_device_v1_t(p); });
+}
+
+cursor_shape_device_v1_t cursor_shape_device_v1_t::proxy_create_wrapper()
+{
+  return {*this, construct_proxy_wrapper_tag()};
+}
+
+const std::string cursor_shape_device_v1_t::interface_name = "wp_cursor_shape_device_v1";
+
+cursor_shape_device_v1_t::operator wp_cursor_shape_device_v1*() const
+{
+  return reinterpret_cast<wp_cursor_shape_device_v1*> (c_ptr());
+}
+
+void cursor_shape_device_v1_t::set_shape(uint32_t serial, cursor_shape_device_v1_shape const& shape)
+{
+  marshal(1U, serial, static_cast<uint32_t>(shape));
+}
+
+
+int cursor_shape_device_v1_t::dispatcher(uint32_t opcode, const std::vector<any>& args, const std::shared_ptr<detail::events_base_t>& e)
+{
+  return 0;
+}
+
+
+
+

--- a/src/window/wayland/wl_cursor_shape.hpp
+++ b/src/window/wayland/wl_cursor_shape.hpp
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <wayland-client.hpp>
+#include <wayland-client-protocol-unstable.hpp>
+
+struct wp_cursor_shape_manager_v1;
+struct wp_cursor_shape_device_v1;
+
+namespace wayland
+{
+class cursor_shape_manager_v1_t;
+class cursor_shape_device_v1_t;
+enum class cursor_shape_device_v1_shape : uint32_t;
+enum class cursor_shape_device_v1_error : uint32_t;
+
+namespace detail
+{
+  extern const wl_interface cursor_shape_manager_v1_interface;
+  extern const wl_interface cursor_shape_device_v1_interface;
+}
+
+/** \brief cursor shape manager
+
+      This global offers an alternative, optional way to set cursor images. This
+      new way uses enumerated cursors instead of a wl_surface like
+      wl_pointer.set_cursor does.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    
+*/
+class cursor_shape_manager_v1_t : public proxy_t
+{
+private:
+  struct events_t : public detail::events_base_t
+  {
+  };
+
+  static int dispatcher(uint32_t opcode, const std::vector<detail::any>& args, const std::shared_ptr<detail::events_base_t>& e);
+
+  cursor_shape_manager_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/);
+
+public:
+  cursor_shape_manager_v1_t();
+  explicit cursor_shape_manager_v1_t(const proxy_t &proxy);
+  cursor_shape_manager_v1_t(wp_cursor_shape_manager_v1 *p, wrapper_type t = wrapper_type::standard);
+
+  cursor_shape_manager_v1_t proxy_create_wrapper();
+
+  static const std::string interface_name;
+
+  operator wp_cursor_shape_manager_v1*() const;
+
+  /** \brief manage the cursor shape of a pointer device
+      \param pointer 
+
+        Obtain a wp_cursor_shape_device_v1 for a wl_pointer object.
+
+        When the pointer capability is removed from the wl_seat, the
+        wp_cursor_shape_device_v1 object becomes inert.
+      
+  */
+  cursor_shape_device_v1_t get_pointer(pointer_t const& pointer);
+
+  /** \brief Minimum protocol version required for the \ref get_pointer function
+  */
+  static constexpr std::uint32_t get_pointer_since_version = 1;
+
+  /** \brief manage the cursor shape of a tablet tool device
+      \param tablet_tool 
+
+        Obtain a wp_cursor_shape_device_v1 for a zwp_tablet_tool_v2 object.
+
+        When the zwp_tablet_tool_v2 is removed, the wp_cursor_shape_device_v1
+        object becomes inert.
+      
+  */
+  cursor_shape_device_v1_t get_tablet_tool_v2(zwp_tablet_tool_v2_t const& tablet_tool);
+
+  /** \brief Minimum protocol version required for the \ref get_tablet_tool_v2 function
+  */
+  static constexpr std::uint32_t get_tablet_tool_v2_since_version = 1;
+
+};
+
+
+/** \brief cursor shape for a device
+
+      This interface allows clients to set the cursor shape.
+    
+*/
+class cursor_shape_device_v1_t : public proxy_t
+{
+private:
+  struct events_t : public detail::events_base_t
+  {
+  };
+
+  static int dispatcher(uint32_t opcode, const std::vector<detail::any>& args, const std::shared_ptr<detail::events_base_t>& e);
+
+  cursor_shape_device_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/);
+
+public:
+  cursor_shape_device_v1_t();
+  explicit cursor_shape_device_v1_t(const proxy_t &proxy);
+  cursor_shape_device_v1_t(wp_cursor_shape_device_v1 *p, wrapper_type t = wrapper_type::standard);
+
+  cursor_shape_device_v1_t proxy_create_wrapper();
+
+  static const std::string interface_name;
+
+  operator wp_cursor_shape_device_v1*() const;
+
+  /** \brief set device cursor to the shape
+      \param serial serial number of the enter event
+      \param shape 
+
+        Sets the device cursor to the specified shape. The compositor will
+        change the cursor image based on the specified shape.
+
+        The cursor actually changes only if the input device focus is one of
+        the requesting client's surfaces. If any, the previous cursor image
+        (surface or shape) is replaced.
+
+        The "shape" argument must be a valid enum entry, otherwise the
+        invalid_shape protocol error is raised.
+
+        This is similar to the wl_pointer.set_cursor and
+        zwp_tablet_tool_v2.set_cursor requests, but this request accepts a
+        shape instead of contents in the form of a surface. Clients can mix
+        set_cursor and set_shape requests.
+
+        The serial parameter must match the latest wl_pointer.enter or
+        zwp_tablet_tool_v2.proximity_in serial number sent to the client.
+        Otherwise the request will be ignored.
+      
+  */
+  void set_shape(uint32_t serial, cursor_shape_device_v1_shape const& shape);
+
+  /** \brief Minimum protocol version required for the \ref set_shape function
+  */
+  static constexpr std::uint32_t set_shape_since_version = 1;
+
+};
+
+/** \brief cursor shapes
+
+        This enum describes cursor shapes.
+
+        The names are taken from the CSS W3C specification:
+        https://w3c.github.io/csswg-drafts/css-ui/#cursor
+        with a few additions.
+
+        Note that there are some groups of cursor shapes that are related:
+        The first group is drag-and-drop cursors which are used to indicate
+        the selected action during dnd operations. The second group is resize
+        cursors which are used to indicate resizing and moving possibilities
+        on window borders. It is recommended that the shapes in these groups
+        should use visually compatible images and metaphors.
+      
+  */
+enum class cursor_shape_device_v1_shape : uint32_t
+  {
+  /** \brief default cursor */
+  _default = 1,
+  /** \brief a context menu is available for the object under the cursor */
+  context_menu = 2,
+  /** \brief help is available for the object under the cursor */
+  help = 3,
+  /** \brief pointer that indicates a link or another interactive element */
+  pointer = 4,
+  /** \brief progress indicator */
+  progress = 5,
+  /** \brief program is busy, user should wait */
+  wait = 6,
+  /** \brief a cell or set of cells may be selected */
+  cell = 7,
+  /** \brief simple crosshair */
+  crosshair = 8,
+  /** \brief text may be selected */
+  text = 9,
+  /** \brief vertical text may be selected */
+  vertical_text = 10,
+  /** \brief drag-and-drop: alias of/shortcut to something is to be created */
+  alias = 11,
+  /** \brief drag-and-drop: something is to be copied */
+  copy = 12,
+  /** \brief drag-and-drop: something is to be moved */
+  move = 13,
+  /** \brief drag-and-drop: the dragged item cannot be dropped at the current cursor location */
+  no_drop = 14,
+  /** \brief drag-and-drop: the requested action will not be carried out */
+  not_allowed = 15,
+  /** \brief drag-and-drop: something can be grabbed */
+  grab = 16,
+  /** \brief drag-and-drop: something is being grabbed */
+  grabbing = 17,
+  /** \brief resizing: the east border is to be moved */
+  e_resize = 18,
+  /** \brief resizing: the north border is to be moved */
+  n_resize = 19,
+  /** \brief resizing: the north-east corner is to be moved */
+  ne_resize = 20,
+  /** \brief resizing: the north-west corner is to be moved */
+  nw_resize = 21,
+  /** \brief resizing: the south border is to be moved */
+  s_resize = 22,
+  /** \brief resizing: the south-east corner is to be moved */
+  se_resize = 23,
+  /** \brief resizing: the south-west corner is to be moved */
+  sw_resize = 24,
+  /** \brief resizing: the west border is to be moved */
+  w_resize = 25,
+  /** \brief resizing: the east and west borders are to be moved */
+  ew_resize = 26,
+  /** \brief resizing: the north and south borders are to be moved */
+  ns_resize = 27,
+  /** \brief resizing: the north-east and south-west corners are to be moved */
+  nesw_resize = 28,
+  /** \brief resizing: the north-west and south-east corners are to be moved */
+  nwse_resize = 29,
+  /** \brief resizing: that the item/column can be resized horizontally */
+  col_resize = 30,
+  /** \brief resizing: that the item/row can be resized vertically */
+  row_resize = 31,
+  /** \brief something can be scrolled in any direction */
+  all_scroll = 32,
+  /** \brief something can be zoomed in */
+  zoom_in = 33,
+  /** \brief something can be zoomed out */
+  zoom_out = 34,
+  /** \brief drag-and-drop: the user will select which action will be carried out (non-css value) */
+  dnd_ask = 35,
+  /** \brief resizing: something can be moved or resized in any direction (non-css value) */
+  all_resize = 36
+};
+
+/** \brief 
+
+  */
+enum class cursor_shape_device_v1_error : uint32_t
+  {
+  /** \brief the specified shape value is invalid */
+  invalid_shape = 1
+};
+
+
+
+}

--- a/src/window/wayland/wl_xdg_toplevel_icon.cpp
+++ b/src/window/wayland/wl_xdg_toplevel_icon.cpp
@@ -1,0 +1,267 @@
+#include "wl_xdg_toplevel_icon.hpp"
+
+using namespace wayland;
+using namespace wayland::detail;
+
+const wl_interface* xdg_toplevel_icon_manager_v1_interface_destroy_request[0] = {
+};
+
+const wl_interface* xdg_toplevel_icon_manager_v1_interface_create_icon_request[1] = {
+  &xdg_toplevel_icon_v1_interface,
+};
+
+const wl_interface* xdg_toplevel_icon_manager_v1_interface_set_icon_request[2] = {
+  &xdg_toplevel_interface,
+  &xdg_toplevel_icon_v1_interface,
+};
+
+const wl_interface* xdg_toplevel_icon_manager_v1_interface_icon_size_event[1] = {
+  nullptr,
+};
+
+const wl_interface* xdg_toplevel_icon_manager_v1_interface_done_event[0] = {
+};
+
+const wl_message xdg_toplevel_icon_manager_v1_interface_requests[3] = {
+  {
+    "destroy",
+    "",
+    xdg_toplevel_icon_manager_v1_interface_destroy_request,
+  },
+  {
+    "create_icon",
+    "n",
+    xdg_toplevel_icon_manager_v1_interface_create_icon_request,
+  },
+  {
+    "set_icon",
+    "o?o",
+    xdg_toplevel_icon_manager_v1_interface_set_icon_request,
+  },
+};
+
+const wl_message xdg_toplevel_icon_manager_v1_interface_events[2] = {
+  {
+    "icon_size",
+    "i",
+    xdg_toplevel_icon_manager_v1_interface_icon_size_event,
+  },
+  {
+    "done",
+    "",
+    xdg_toplevel_icon_manager_v1_interface_done_event,
+  },
+};
+
+const wl_interface wayland::detail::xdg_toplevel_icon_manager_v1_interface =
+  {
+    "xdg_toplevel_icon_manager_v1",
+    1,
+    3,
+    xdg_toplevel_icon_manager_v1_interface_requests,
+    2,
+    xdg_toplevel_icon_manager_v1_interface_events,
+  };
+
+const wl_interface* xdg_toplevel_icon_v1_interface_destroy_request[0] = {
+};
+
+const wl_interface* xdg_toplevel_icon_v1_interface_set_name_request[1] = {
+  nullptr,
+};
+
+const wl_interface* xdg_toplevel_icon_v1_interface_add_buffer_request[2] = {
+  &buffer_interface,
+  nullptr,
+};
+
+const wl_message xdg_toplevel_icon_v1_interface_requests[3] = {
+  {
+    "destroy",
+    "",
+    xdg_toplevel_icon_v1_interface_destroy_request,
+  },
+  {
+    "set_name",
+    "s",
+    xdg_toplevel_icon_v1_interface_set_name_request,
+  },
+  {
+    "add_buffer",
+    "oi",
+    xdg_toplevel_icon_v1_interface_add_buffer_request,
+  },
+};
+
+const wl_message xdg_toplevel_icon_v1_interface_events[0] = {
+};
+
+const wl_interface wayland::detail::xdg_toplevel_icon_v1_interface =
+  {
+    "xdg_toplevel_icon_v1",
+    1,
+    3,
+    xdg_toplevel_icon_v1_interface_requests,
+    0,
+    xdg_toplevel_icon_v1_interface_events,
+  };
+
+xdg_toplevel_icon_manager_v1_t::xdg_toplevel_icon_manager_v1_t(const proxy_t &p)
+  : proxy_t(p)
+{
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&xdg_toplevel_icon_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_manager_v1_t(p); });
+}
+
+xdg_toplevel_icon_manager_v1_t::xdg_toplevel_icon_manager_v1_t()
+{
+  set_interface(&xdg_toplevel_icon_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_manager_v1_t(p); });
+}
+
+xdg_toplevel_icon_manager_v1_t::xdg_toplevel_icon_manager_v1_t(xdg_toplevel_icon_manager_v1 *p, wrapper_type t)
+  : proxy_t(reinterpret_cast<wl_proxy*> (p), t){
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&xdg_toplevel_icon_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_manager_v1_t(p); });
+}
+
+xdg_toplevel_icon_manager_v1_t::xdg_toplevel_icon_manager_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/)
+  : proxy_t(wrapped_proxy, construct_proxy_wrapper_tag()){
+  set_interface(&xdg_toplevel_icon_manager_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_manager_v1_t(p); });
+}
+
+xdg_toplevel_icon_manager_v1_t xdg_toplevel_icon_manager_v1_t::proxy_create_wrapper()
+{
+  return {*this, construct_proxy_wrapper_tag()};
+}
+
+const std::string xdg_toplevel_icon_manager_v1_t::interface_name = "xdg_toplevel_icon_manager_v1";
+
+xdg_toplevel_icon_manager_v1_t::operator xdg_toplevel_icon_manager_v1*() const
+{
+  return reinterpret_cast<xdg_toplevel_icon_manager_v1*> (c_ptr());
+}
+
+xdg_toplevel_icon_v1_t xdg_toplevel_icon_manager_v1_t::create_icon()
+{
+  proxy_t p = marshal_constructor(1U, &xdg_toplevel_icon_v1_interface, nullptr);
+  return xdg_toplevel_icon_v1_t(p);
+}
+
+
+void xdg_toplevel_icon_manager_v1_t::set_icon(xdg_toplevel_t const& toplevel, xdg_toplevel_icon_v1_t const& icon)
+{
+  marshal(2U, toplevel.proxy_has_object() ? reinterpret_cast<wl_object*>(toplevel.c_ptr()) : nullptr, icon.proxy_has_object() ? reinterpret_cast<wl_object*>(icon.c_ptr()) : nullptr);
+}
+
+
+std::function<void(int32_t)> &xdg_toplevel_icon_manager_v1_t::on_icon_size()
+{
+  return std::static_pointer_cast<events_t>(get_events())->icon_size;
+}
+
+std::function<void()> &xdg_toplevel_icon_manager_v1_t::on_done()
+{
+  return std::static_pointer_cast<events_t>(get_events())->done;
+}
+
+int xdg_toplevel_icon_manager_v1_t::dispatcher(uint32_t opcode, const std::vector<any>& args, const std::shared_ptr<detail::events_base_t>& e)
+{
+  std::shared_ptr<events_t> events = std::static_pointer_cast<events_t>(e);
+  switch(opcode)
+    {
+    case 0:
+      if(events->icon_size) events->icon_size(args[0].get<int32_t>());
+      break;
+    case 1:
+      if(events->done) events->done();
+      break;
+    }
+  return 0;
+}
+
+xdg_toplevel_icon_v1_t::xdg_toplevel_icon_v1_t(const proxy_t &p)
+  : proxy_t(p)
+{
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&xdg_toplevel_icon_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_v1_t(p); });
+}
+
+xdg_toplevel_icon_v1_t::xdg_toplevel_icon_v1_t()
+{
+  set_interface(&xdg_toplevel_icon_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_v1_t(p); });
+}
+
+xdg_toplevel_icon_v1_t::xdg_toplevel_icon_v1_t(xdg_toplevel_icon_v1 *p, wrapper_type t)
+  : proxy_t(reinterpret_cast<wl_proxy*> (p), t){
+  if(proxy_has_object() && get_wrapper_type() == wrapper_type::standard)
+    {
+      set_events(std::shared_ptr<detail::events_base_t>(new events_t), dispatcher);
+      set_destroy_opcode(0U);
+    }
+  set_interface(&xdg_toplevel_icon_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_v1_t(p); });
+}
+
+xdg_toplevel_icon_v1_t::xdg_toplevel_icon_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/)
+  : proxy_t(wrapped_proxy, construct_proxy_wrapper_tag()){
+  set_interface(&xdg_toplevel_icon_v1_interface);
+  set_copy_constructor([] (const proxy_t &p) -> proxy_t
+    { return xdg_toplevel_icon_v1_t(p); });
+}
+
+xdg_toplevel_icon_v1_t xdg_toplevel_icon_v1_t::proxy_create_wrapper()
+{
+  return {*this, construct_proxy_wrapper_tag()};
+}
+
+const std::string xdg_toplevel_icon_v1_t::interface_name = "xdg_toplevel_icon_v1";
+
+xdg_toplevel_icon_v1_t::operator xdg_toplevel_icon_v1*() const
+{
+  return reinterpret_cast<xdg_toplevel_icon_v1*> (c_ptr());
+}
+
+void xdg_toplevel_icon_v1_t::set_name(std::string const& icon_name)
+{
+  marshal(1U, icon_name);
+}
+
+
+void xdg_toplevel_icon_v1_t::add_buffer(buffer_t const& buffer, int32_t scale)
+{
+  marshal(2U, buffer.proxy_has_object() ? reinterpret_cast<wl_object*>(buffer.c_ptr()) : nullptr, scale);
+}
+
+
+int xdg_toplevel_icon_v1_t::dispatcher(uint32_t opcode, const std::vector<any>& args, const std::shared_ptr<detail::events_base_t>& e)
+{
+  return 0;
+}
+
+
+

--- a/src/window/wayland/wl_xdg_toplevel_icon.hpp
+++ b/src/window/wayland/wl_xdg_toplevel_icon.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <wayland-client.hpp>
+#include <wayland-client-protocol-extra.hpp>
+
+struct xdg_toplevel_icon_manager_v1;
+struct xdg_toplevel_icon_v1;
+
+namespace wayland
+{
+class xdg_toplevel_icon_manager_v1_t;
+class xdg_toplevel_icon_v1_t;
+enum class xdg_toplevel_icon_v1_error : uint32_t;
+
+namespace detail
+{
+  extern const wl_interface xdg_toplevel_icon_manager_v1_interface;
+  extern const wl_interface xdg_toplevel_icon_v1_interface;
+}
+
+/** \brief interface to manage toplevel icons
+
+      This interface allows clients to create toplevel window icons and set
+      them on toplevel windows to be displayed to the user.
+    
+*/
+class xdg_toplevel_icon_manager_v1_t : public proxy_t
+{
+private:
+  struct events_t : public detail::events_base_t
+  {
+    std::function<void(int32_t)> icon_size;
+    std::function<void()> done;
+  };
+
+  static int dispatcher(uint32_t opcode, const std::vector<detail::any>& args, const std::shared_ptr<detail::events_base_t>& e);
+
+  xdg_toplevel_icon_manager_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/);
+
+public:
+  xdg_toplevel_icon_manager_v1_t();
+  explicit xdg_toplevel_icon_manager_v1_t(const proxy_t &proxy);
+  xdg_toplevel_icon_manager_v1_t(xdg_toplevel_icon_manager_v1 *p, wrapper_type t = wrapper_type::standard);
+
+  xdg_toplevel_icon_manager_v1_t proxy_create_wrapper();
+
+  static const std::string interface_name;
+
+  operator xdg_toplevel_icon_manager_v1*() const;
+
+  /** \brief create a new icon instance
+
+        Creates a new icon object. This icon can then be attached to a
+        xdg_toplevel via the 'set_icon' request.
+      
+  */
+  xdg_toplevel_icon_v1_t create_icon();
+
+  /** \brief Minimum protocol version required for the \ref create_icon function
+  */
+  static constexpr std::uint32_t create_icon_since_version = 1;
+
+  /** \brief set an icon on a toplevel window
+      \param toplevel the toplevel to act on
+      \param icon 
+
+        This request assigns the icon 'icon' to 'toplevel', or clears the
+        toplevel icon if 'icon' was null.
+        This state is double-buffered and is applied on the next
+        wl_surface.commit of the toplevel.
+
+        After making this call, the xdg_toplevel_icon_v1 provided as 'icon'
+        can be destroyed by the client without 'toplevel' losing its icon.
+        The xdg_toplevel_icon_v1 is immutable from this point, and any
+        future attempts to change it must raise the
+        'xdg_toplevel_icon_v1.immutable' protocol error.
+
+        The compositor must set the toplevel icon from either the pixel data
+        the icon provides, or by loading a stock icon using the icon name.
+        See the description of 'xdg_toplevel_icon_v1' for details.
+
+        If 'icon' is set to null, the icon of the respective toplevel is reset
+        to its default icon (usually the icon of the application, derived from
+        its desktop-entry file, or a placeholder icon).
+        If this request is passed an icon with no pixel buffers or icon name
+        assigned, the icon must be reset just like if 'icon' was null.
+      
+  */
+  void set_icon(xdg_toplevel_t const& toplevel, xdg_toplevel_icon_v1_t const& icon);
+
+  /** \brief Minimum protocol version required for the \ref set_icon function
+  */
+  static constexpr std::uint32_t set_icon_since_version = 1;
+
+  /** \brief describes a supported & preferred icon size
+      \param size the edge size of the square icon in surface-local coordinates, e.g. 64
+
+        This event indicates an icon size the compositor prefers to be
+        available if the client has scalable icons and can render to any size.
+
+        When the 'xdg_toplevel_icon_manager_v1' object is created, the
+        compositor may send one or more 'icon_size' events to describe the list
+        of preferred icon sizes. If the compositor has no size preference, it
+        may not send any 'icon_size' event, and it is up to the client to
+        decide a suitable icon size.
+
+        A sequence of 'icon_size' events must be finished with a 'done' event.
+        If the compositor has no size preferences, it must still send the
+        'done' event, without any preceding 'icon_size' events.
+      
+  */
+  std::function<void(int32_t)> &on_icon_size();
+
+  /** \brief all information has been sent
+
+        This event is sent after all 'icon_size' events have been sent.
+      
+  */
+  std::function<void()> &on_done();
+
+};
+
+
+/** \brief a toplevel window icon
+
+      This interface defines a toplevel icon.
+      An icon can have a name, and multiple buffers.
+      In order to be applied, the icon must have either a name, or at least
+      one buffer assigned. Applying an empty icon (with no buffer or name) to
+      a toplevel should reset its icon to the default icon.
+
+      It is up to compositor policy whether to prefer using a buffer or loading
+      an icon via its name. See 'set_name' and 'add_buffer' for details.
+    
+*/
+class xdg_toplevel_icon_v1_t : public proxy_t
+{
+private:
+  struct events_t : public detail::events_base_t
+  {
+  };
+
+  static int dispatcher(uint32_t opcode, const std::vector<detail::any>& args, const std::shared_ptr<detail::events_base_t>& e);
+
+  xdg_toplevel_icon_v1_t(proxy_t const &wrapped_proxy, construct_proxy_wrapper_tag /*unused*/);
+
+public:
+  xdg_toplevel_icon_v1_t();
+  explicit xdg_toplevel_icon_v1_t(const proxy_t &proxy);
+  xdg_toplevel_icon_v1_t(xdg_toplevel_icon_v1 *p, wrapper_type t = wrapper_type::standard);
+
+  xdg_toplevel_icon_v1_t proxy_create_wrapper();
+
+  static const std::string interface_name;
+
+  operator xdg_toplevel_icon_v1*() const;
+
+  /** \brief set an icon name
+      \param icon_name 
+
+        This request assigns an icon name to this icon.
+        Any previously set name is overridden.
+
+        The compositor must resolve 'icon_name' according to the lookup rules
+        described in the XDG icon theme specification[1] using the
+        environment's current icon theme.
+
+        If the compositor does not support icon names or cannot resolve
+        'icon_name' according to the XDG icon theme specification it must
+        fall back to using pixel buffer data instead.
+
+        If this request is made after the icon has been assigned to a toplevel
+        via 'set_icon', a 'immutable' error must be raised.
+
+        [1]: https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
+      
+  */
+  void set_name(std::string const& icon_name);
+
+  /** \brief Minimum protocol version required for the \ref set_name function
+  */
+  static constexpr std::uint32_t set_name_since_version = 1;
+
+  /** \brief add icon data from a pixel buffer
+      \param buffer 
+      \param scale the scaling factor of the icon, e.g. 1
+
+        This request adds pixel data supplied as wl_buffer to the icon.
+
+        The client should add pixel data for all icon sizes and scales that
+        it can provide, or which are explicitly requested by the compositor
+        via 'icon_size' events on xdg_toplevel_icon_manager_v1.
+
+        The wl_buffer supplying pixel data as 'buffer' must be backed by wl_shm
+        and must be a square (width and height being equal).
+        If any of these buffer requirements are not fulfilled, a 'invalid_buffer'
+        error must be raised.
+
+        If this icon instance already has a buffer of the same size and scale
+        from a previous 'add_buffer' request, data from the last request
+        overrides the preexisting pixel data.
+
+        The wl_buffer must be kept alive for as long as the xdg_toplevel_icon
+        it is associated with is not destroyed, otherwise a 'no_buffer' error
+        is raised. The buffer contents must not be modified after it was
+        assigned to the icon. As a result, the region of the wl_shm_pool's
+        backing storage used for the wl_buffer must not be modified after this
+        request is sent. The wl_buffer.release event is unused.
+
+        If this request is made after the icon has been assigned to a toplevel
+        via 'set_icon', a 'immutable' error must be raised.
+      
+  */
+  void add_buffer(buffer_t const& buffer, int32_t scale);
+
+  /** \brief Minimum protocol version required for the \ref add_buffer function
+  */
+  static constexpr std::uint32_t add_buffer_since_version = 1;
+
+};
+
+/** \brief 
+
+  */
+enum class xdg_toplevel_icon_v1_error : uint32_t
+  {
+  /** \brief the provided buffer does not satisfy requirements */
+  invalid_buffer = 1,
+  /** \brief the icon has already been assigned to a toplevel and must not be changed */
+  immutable = 2,
+  /** \brief the provided buffer has been destroyed before the toplevel icon */
+  no_buffer = 3
+};
+
+
+
+}


### PR DESCRIPTION
- Add `xdg_toplevel_icon` and `cursor_shape` protocols support
- Implement `WaylandDisplayWindow::SetWindowIcon()` based on the `xdg_toplevel_icon` protocol.