### PR TITLE
Wayland Backend: Use unaccelerated dx and dy for OnMouseMoveRawEvent()

### DIFF
--- a/src/window/wayland/wayland_display_backend.cpp
+++ b/src/window/wayland/wayland_display_backend.cpp
@@ -336,6 +336,8 @@ void WaylandDisplayBackend::ConnectDeviceEvents()
 		currentPointerEvent.time = utime_lo;
 		currentPointerEvent.dx = dx;
 		currentPointerEvent.dy = dy;
+		currentPointerEvent.dx_unaccel = dx_unaccel;
+		currentPointerEvent.dy_unaccel = dy_unaccel;
 	};
 
 	m_waylandPointer.on_frame() = [this] () {
@@ -353,7 +355,7 @@ void WaylandDisplayBackend::ConnectDeviceEvents()
 		if (currentPointerEvent.event_mask & POINTER_EVENT_RELATIVE_MOTION)
 		{
 			if (hasMouseLock)
-				OnMouseMoveRawEvent(int(currentPointerEvent.dx), int(currentPointerEvent.dy));
+				OnMouseMoveRawEvent(int(currentPointerEvent.dx_unaccel), int(currentPointerEvent.dy_unaccel));
 		}
 
 		if (currentPointerEvent.event_mask & POINTER_EVENT_BUTTON)

--- a/src/window/wayland/wayland_display_backend.h
+++ b/src/window/wayland/wayland_display_backend.h
@@ -50,7 +50,7 @@ struct WaylandPointerEvent
 {
 	uint32_t event_mask;
 	double surfaceX, surfaceY;
-	double dx, dy;
+	double dx, dy, dx_unaccel, dy_unaccel;
 	uint32_t button;
 	wayland::pointer_button_state state;
 	uint32_t time;


### PR DESCRIPTION
This fixes the quite small mouse movements being "ignored" issue.