### PR TITLE
Some minor Wayland backend changes

### DIFF
--- a/src/window/wayland/wayland_display_backend.cpp
+++ b/src/window/wayland/wayland_display_backend.cpp
@@ -258,8 +258,6 @@ void WaylandDisplayBackend::ConnectDeviceEvents()
 		xkb_state_key_get_utf8(m_KeyboardState, key + 8, buf, sizeof(buf));
 
 		OnKeyboardCharEvent(buf, state);
-
-		//m_DataDevice.set_selection(m_DataSource, m_KeyboardSerial);
 	};
 
 	m_waylandPointer.on_enter() = [this](uint32_t serial, wayland::surface_t surfaceEntered, double surfaceX, double surfaceY) {
@@ -274,6 +272,8 @@ void WaylandDisplayBackend::ConnectDeviceEvents()
 				if (win->GetWindowSurface() == surfaceEntered)
 				{
 					m_MouseFocusWindow = win;
+					ShowCursor(!m_MouseFocusWindow->m_LockedPointer);
+					break;
 				}
 			}
 		}
@@ -486,13 +486,18 @@ void WaylandDisplayBackend::OnMouseLeaveEvent()
 	{
 		m_MouseFocusWindow->windowHost->OnWindowMouseLeave();
 		//m_MouseFocusWindow = nullptr; // Borks up the menus
+		ShowCursor(!m_MouseFocusWindow->m_LockedPointer);
 	}
 }
 
 void WaylandDisplayBackend::OnMousePressEvent(InputKey button)
 {
 	if (m_MouseFocusWindow)
+	{
 		m_MouseFocusWindow->windowHost->OnWindowMouseDown(m_MouseFocusWindow->m_SurfaceMousePos, button);
+		ShowCursor(m_MouseFocusWindow->m_LockedPointer);
+	}
+
 }
 
 void WaylandDisplayBackend::OnMouseReleaseEvent(InputKey button)

--- a/src/window/wayland/wayland_display_backend.h
+++ b/src/window/wayland/wayland_display_backend.h
@@ -126,6 +126,7 @@ public:
 	wayland::data_device_manager_t m_DataDeviceManager;
 	wayland::xdg_wm_base_t m_XDGWMBase;
 	wayland::zwp_pointer_constraints_v1_t m_PointerConstraints;
+	// TODO: XDG_Activation seems to be for activating OTHER XDG_Toplevels. Do we need this?
 	wayland::xdg_activation_v1_t m_XDGActivation;
 	wayland::zxdg_decoration_manager_v1_t m_XDGDecorationManager;
 	wayland::fractional_scale_manager_v1_t m_FractionalScaleManager;

--- a/src/window/wayland/wayland_display_window.h
+++ b/src/window/wayland/wayland_display_window.h
@@ -192,6 +192,9 @@ private:
 	std::vector<std::shared_ptr<SharedMemHelper>> appIconSharedMems;
 	std::vector<wayland::buffer_t> appIconBuffers;
 
+	wayland::xdg_activation_token_v1_t m_WindowActivationToken;
+	std::string m_ActivationTokenString;
+
 	bool isFullscreen = false;
 
 	// Helper functions


### PR DESCRIPTION
- Moved the XDG_Activation_Token_v1 object outside WaylandDisplayWindow::Activate()
- Added a TODO about XDG_Activation object as it seems to be actually used for activating other XDG_Toplevels, so not sure if it will be useful for us here.
- If the window we've clicked on has locked the mouse, hide the cursor.