### PR TITLE
Get screen size correctly in SDL3 backend

### DIFF
--- a/src/window/sdl3/sdl3_display_backend.cpp
+++ b/src/window/sdl3/sdl3_display_backend.cpp
@@ -46,8 +46,10 @@ void SDL3DisplayBackend::ExitLoop()
 Size SDL3DisplayBackend::GetScreenSize()
 {
 	SDL_Rect rect = {};
-	if (!SDL_GetDisplayBounds(0, &rect))
+	SDL_DisplayID *displays = SDL_GetDisplays(nullptr);
+	if (!displays || !SDL_GetDisplayBounds(displays[0], &rect))
 		throw std::runtime_error(std::string("Unable to get screen size:") + SDL_GetError());
+	SDL_free(displays);
 
 	return {rect.w / UIScale, rect.h / UIScale};
 }


### PR DESCRIPTION
In SDL2, SDL_GetDisplayBounds took a display index, but in SDL3 it takes an SDL_DisplayID, of which 0 is invalid.