### PR TITLE
Changed delegate for ZWidget to choose whether an external applicatio…

### DIFF
--- a/src/window/cocoa/cocoa_display_backend.mm
+++ b/src/window/cocoa/cocoa_display_backend.mm
@@ -46,13 +46,19 @@ std::unique_ptr<DisplayBackend> DisplayBackend::TryCreateCocoa()
     return std::make_unique<CocoaDisplayBackend>();
 }
 
-
 CocoaDisplayBackend::CocoaDisplayBackend()
 {
-    // CRITICAL: Initialize NSApp and set activation policy for keyboard events
+    // Initialize NSApp if not already done
     [NSApplication sharedApplication];
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-    [NSApp finishLaunching];
+
+    // Only configure NSApp if we're the owner (no delegate set yet)
+    if ([NSApp delegate] == nil)
+    {
+        // We're the primary app - set activation policy for keyboard events
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp finishLaunching];
+    }
+    // else: Parent app is managing NSApp lifecycle, don't interfere
 }
 
 CocoaDisplayBackend::~CocoaDisplayBackend()


### PR DESCRIPTION
Current subwindows fight for control with the main window. This change will allow the main game window to control ZWidget's lifecycle and event handling so both windows are not fighting for control.