### PR TITLE
Add support for scrolling TextEdit by mouse wheel

### DIFF
--- a/include/zwidget/widgets/textedit/textedit.h
+++ b/include/zwidget/widgets/textedit/textedit.h
@@ -61,6 +61,7 @@ protected:
 	void OnKeyChar(std::string chars) override;
 	void OnKeyDown(InputKey key) override;
 	void OnKeyUp(InputKey key) override;
+	bool OnMouseWheel(const Point& pos, InputKey key) override;
 	void OnGeometryChanged() override;
 	void OnEnableChanged() override;
 	void OnSetFocus() override;

--- a/src/widgets/textedit/textedit.cpp
+++ b/src/widgets/textedit/textedit.cpp
@@ -551,6 +551,19 @@ void TextEdit::OnKeyUp(InputKey key)
 {
 }
 
+bool TextEdit::OnMouseWheel(const Point& pos, InputKey key)
+{
+	if (key == InputKey::MouseWheelUp)
+	{
+		vert_scrollbar->SetPosition(vert_scrollbar->GetPosition() - 1);
+	}
+	else if (key == InputKey::MouseWheelDown)
+	{
+		vert_scrollbar->SetPosition(vert_scrollbar->GetPosition() + 1);
+	}
+	return true;
+}
+
 void TextEdit::OnSetFocus()
 {
 	if (!readonly)


### PR DESCRIPTION
Scrolling one line at a time might not be very convenient, but I found that the scroll bar progress of the `TextEdit` is based on logical lines rather than the number of lines after automatic line breaks.
Maybe it can be improved further in the future. At least for now, let the mouse wheel have an effect.